### PR TITLE
API(posts)の更新をした。

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,3 +25,23 @@ Style/TrailingCommaInArguments:
 
 Style/TrailingCommaInLiteral:
   Enabled: false
+
+Metrics/ClassLength:
+  Exclude:
+    - 'app/apis/api/v1/**/*'
+    - 'spec/apis/api/v1/**/*'
+
+Metrics/BlockLength:
+  Exclude:
+    - 'app/apis/api/v1/**/*'
+    - 'spec/apis/api/v1/**/*'
+
+Metrics/ModuleLength:
+  Exclude:
+    - 'app/apis/api/v1/**/*'
+    - 'spec/apis/api/v1/**/*'
+
+Naming/FileName:
+  Exclude:
+    - 'spec/support/rspec-json_expectations.rb'
+

--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ group :test do
   gem 'rspec-rails'
   gem 'spring-commands-rspec'
   gem 'database_rewinder'
+  gem 'rspec-json_expectations'
 end
 
 gem 'grape'                   # Grapeを使うときのGem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,6 +173,7 @@ GEM
     rspec-expectations (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
+    rspec-json_expectations (2.1.0)
     rspec-mocks (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
@@ -252,6 +253,7 @@ DEPENDENCIES
   rack-cors
   rails (~> 5.1.4)
   rails-erd
+  rspec-json_expectations
   rspec-rails
   rubocop
   seed-fu

--- a/app/apis/api/v1/user/posts.rb
+++ b/app/apis/api/v1/user/posts.rb
@@ -9,8 +9,7 @@ module API
           end
 
           def post_with_revision_params
-            ActionController::Parameters.new(params).permit(
-              :newest_revision_id,
+            ActionController::Parameters.new(customize_params).permit(
               revisions_attributes: %i[
                 title
                 summary
@@ -23,12 +22,50 @@ module API
             )
           end
 
+          def customize_params
+            if params["revisions_attributes"].nil?
+              params
+            else
+              dup_params = params.dup
+              dup_params["revisions_attributes"] = {}
+              dup_params["revisions_attributes"]["1"] = params["revisions_attributes"].dup
+              dup_params
+            end
+          end
+
           def set_post
             @post = current_user.posts.find(params[:id])
           end
 
           params :user_id do
             requires :user_id, type: Integer
+          end
+
+          # 参考
+          # param_typeを指定しないとだめ
+          # https://qiita.com/gamerinshaft/items/5cddcd38869d1238e688
+          params :revisions_attributes do
+            requires :revisions_attributes, type: Hash do
+              requires :title,     type: String, documentation: { param_type: 'body' }
+              requires :summary,   type: String, documentation: { param_type: 'body' }
+              requires :goal,      type: String, documentation: { param_type: 'body' }
+              optional :comment,   type: String, documentation: { param_type: 'body' }
+              optional :event_url, type: String, documentation: { param_type: 'body' }
+              requires :body,      type: String, documentation: { param_type: 'body' }
+              optional :slide_url, type: String, documentation: { param_type: 'body' }
+            end
+          end
+
+          params :revisions_attributes_optional do
+            requires :revisions_attributes, type: Hash do
+              optional :title,     type: String, documentation: { param_type: 'body' }
+              optional :summary,   type: String, documentation: { param_type: 'body' }
+              optional :goal,      type: String, documentation: { param_type: 'body' }
+              optional :comment,   type: String, documentation: { param_type: 'body' }
+              optional :event_url, type: String, documentation: { param_type: 'body' }
+              optional :body,      type: String, documentation: { param_type: 'body' }
+              optional :slide_url, type: String, documentation: { param_type: 'body' }
+            end
           end
         end
 
@@ -57,10 +94,7 @@ module API
                 failure: [{ code: 422, message: 'Unprocessable Entity' }]
               }
               params do
-                # 参考
-                # param_typeを指定しないとだめ
-                # https://qiita.com/gamerinshaft/items/5cddcd38869d1238e688
-                requires :newest_revision_id, type: Integer, documentation: { param_type: 'body' }
+                use :revisions_attributes
               end
               post do
                 post = current_user.posts.build(post_with_revision_params)
@@ -76,7 +110,7 @@ module API
               }
               params do
                 requires :id, type: Integer
-                optional :newest_revision_id, type: Integer, documentation: { param_type: 'body' }
+                use :revisions_attributes_optional
               end
               patch ':id' do
                 set_post
@@ -92,7 +126,7 @@ module API
               }
               params do
                 requires :id, type: Integer
-                optional :newest_revision_id, type: Integer, documentation: { param_type: 'body' }
+                use :revisions_attributes_optional
               end
               put ':id' do
                 set_post

--- a/app/apis/api/v1/user/posts.rb
+++ b/app/apis/api/v1/user/posts.rb
@@ -37,6 +37,12 @@ module API
             @post = current_user.posts.find(params[:id])
           end
 
+          def revisions_each_related_post
+            current_user.posts.map do |post|
+              post.revisions.last
+            end
+          end
+
           params :user_id do
             requires :user_id, type: Integer
           end
@@ -78,7 +84,7 @@ module API
             resource :posts do
               desc '投稿一覧を取得します'
               get do
-                current_user.posts
+                revisions_each_related_post
               end
 
               desc 'idで指定された投稿を取得します'
@@ -87,7 +93,7 @@ module API
               end
               get ':id' do
                 set_post
-                @post
+                @post.revisions.last
               end
 
               desc '投稿を作成します', {
@@ -145,8 +151,9 @@ module API
               end
               delete ':id' do
                 set_post
+                newest_revision_of_post = @post.revisions.last.dup
                 if @post.destroy
-                  @post
+                  newest_revision_of_post
                 else
                   status 422
                 end

--- a/app/apis/api/v1/user/posts.rb
+++ b/app/apis/api/v1/user/posts.rb
@@ -99,7 +99,7 @@ module API
               post do
                 post = current_user.posts.build(post_with_revision_params)
                 if post.save && post.update(newest_revision_id: post.revisions.last.id)
-                  post
+                  post.revisions.last
                 else
                   status 422
                 end
@@ -115,7 +115,7 @@ module API
               patch ':id' do
                 set_post
                 if @post.update(post_with_revision_params) && @post.update(newest_revision_id: @post.revisions.last.id)
-                  @post
+                  @post.revisions.last
                 else
                   status 422
                 end
@@ -131,7 +131,7 @@ module API
               put ':id' do
                 set_post
                 if @post.update(post_with_revision_params)
-                  @post
+                  @post.revisions.last
                 else
                   status 422
                 end

--- a/spec/apis/api/v1/user/posts_spec.rb
+++ b/spec/apis/api/v1/user/posts_spec.rb
@@ -21,11 +21,11 @@ module API
 
         describe 'POST /users/:user_id/posts' do
           let(:post_params)                 { attributes_for(:post, newest_revision_id: nil) }
-          let(:revision_attributes_element) { { "1": attributes_for(:revision) } }
-          let(:revisions_attributes)         { { revisions_attributes: revision_attributes_element } }
+          let(:revision_attributes_element) { attributes_for(:revision) }
+          let(:revisions_attributes)        { { revisions_attributes: revision_attributes_element } }
           let(:post_with_revision_params)   { post_params.merge(revisions_attributes) }
 
-          let(:path)        { "/api/v1/users/#{current_user.id}/posts" }
+          let(:path)                        { "/api/v1/users/#{current_user.id}/posts" }
 
           subject do
             post path, params: post_with_revision_params
@@ -91,7 +91,7 @@ module API
           let!(:post) { create(:post_with_revisions, user: current_user) }
 
           let(:post_params)                 { attributes_for(:post) }
-          let(:revision_attributes_element) { { "1": attributes_for(:revision, title: 'hogehoge') } }
+          let(:revision_attributes_element) { attributes_for(:revision, title: 'hogehoge') }
           let(:revisions_attributes)        { { revisions_attributes: revision_attributes_element } }
           let(:post_with_revision_params)   { post_params.merge(revisions_attributes) }
 

--- a/spec/apis/api/v1/user/posts_spec.rb
+++ b/spec/apis/api/v1/user/posts_spec.rb
@@ -20,12 +20,12 @@ module API
         end
 
         describe 'POST /users/:user_id/posts' do
-          let(:post_params)                 { attributes_for(:post, newest_revision_id: nil) }
-          let(:revision_attributes_element) { attributes_for(:revision) }
-          let(:revisions_attributes)        { { revisions_attributes: revision_attributes_element } }
-          let(:post_with_revision_params)   { post_params.merge(revisions_attributes) }
+          let!(:post_params)                 { attributes_for(:post, newest_revision_id: nil) }
+          let!(:revision_attributes_element) { attributes_for(:revision) }
+          let!(:revisions_attributes)        { { revisions_attributes: revision_attributes_element } }
+          let!(:post_with_revision_params)   { post_params.merge(revisions_attributes) }
 
-          let(:path)                        { "/api/v1/users/#{current_user.id}/posts" }
+          let(:path)                         { "/api/v1/users/#{current_user.id}/posts" }
 
           subject do
             post path, params: post_with_revision_params
@@ -44,6 +44,13 @@ module API
             it '最新の改訂履歴を示すid(newest_revision_id)が更新されること' do
               subject
               expect(::Post.last.newest_revision_id).to eq ::Post.last.revisions.last.id
+            end
+
+            it '投稿(改訂履歴)のjsonが返ってくること' do
+              subject
+              actual   = JSON.parse(response.body)
+              expected = revision_attributes_element
+              expect(actual).to include_json expected
             end
           end
 
@@ -90,10 +97,10 @@ module API
         describe 'PATCH/PUT /users/:user_id/posts/:id (posts#update)' do
           let!(:post) { create(:post_with_revisions, user: current_user) }
 
-          let(:post_params)                 { attributes_for(:post) }
-          let(:revision_attributes_element) { attributes_for(:revision, title: 'hogehoge') }
-          let(:revisions_attributes)        { { revisions_attributes: revision_attributes_element } }
-          let(:post_with_revision_params)   { post_params.merge(revisions_attributes) }
+          let!(:post_params)                 { attributes_for(:post) }
+          let!(:revision_attributes_element) { attributes_for(:revision, title: 'hogehoge') }
+          let!(:revisions_attributes)        { { revisions_attributes: revision_attributes_element } }
+          let!(:post_with_revision_params)   { post_params.merge(revisions_attributes) }
 
           context '正常に投稿が見つかった場合' do
             let(:path) { "/api/v1/users/#{current_user.id}/posts/#{post.id}" }
@@ -125,6 +132,13 @@ module API
               it '最新の改訂履歴を示すid(newest_revision_id)が更新されること' do
                 subject
                 expect(::Post.last.newest_revision_id).to eq ::Post.last.revisions.last.id
+              end
+
+              it '最新の改訂履歴のjsonが返ってくること' do
+                subject
+                actual   = JSON.parse(response.body)
+                expected = revision_attributes_element
+                expect(actual).to include_json expected
               end
             end
 

--- a/spec/support/rspec-json_expectations.rb
+++ b/spec/support/rspec-json_expectations.rb
@@ -1,0 +1,3 @@
+# 参考
+# https://relishapp.com/waterlink/rspec-json-expectations/docs/json-expectations/include-json-matcher
+require "rspec/json_expectations"


### PR DESCRIPTION
## ストーリー
ない

## 概要
投稿のAPIを叩いて返ってくるjsonが改訂履歴の情報を含んでなく、
フロント側で結果を扱いにくかったので改訂履歴の情報を含ませるようにした。

この修正がないと、投稿のAPIと改訂履歴のAPIを叩いてはじめて、投稿内容がわかるという
使いにくいAPIになってしまう。