### PR TITLE
API(likes)の実装をした

### DIFF
--- a/app/apis/api/v1/root.rb
+++ b/app/apis/api/v1/root.rb
@@ -28,6 +28,7 @@ module API
       mount API::V1::Posts
       mount API::V1::Revisions
       mount API::V1::Likes
+      mount API::V1::User::Likes
       mount API::V1::Post::Likes
       mount API::V1::Setting::Profile
 

--- a/app/apis/api/v1/user/likes.rb
+++ b/app/apis/api/v1/user/likes.rb
@@ -1,0 +1,27 @@
+module API
+  module V1
+    module User
+      class Likes < Grape::API
+        helpers do
+          def set_user
+            # https://github.com/ruby-grape/grape#Current Route and Endpoint
+            @user = ::User.find_by(mention_name: params[:mention_name])
+          end
+        end
+
+        route_param :mention_name do
+          resource :post_likes do
+            desc '「いいね！」の一覧を取得します'
+            get do
+              set_user
+              # TODO: 現在は投稿に関する「いいね！」だけを考えているが、
+              #       チャットに対しての「いいね！」も考えるようになったら、
+              #       current_user.chat_likesも足すようにする。
+              @user.post_likes
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20180226145852_add_mention_name_to_user.rb
+++ b/db/migrate/20180226145852_add_mention_name_to_user.rb
@@ -1,0 +1,7 @@
+class AddMentionNameToUser < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :mention_name, :string, after: :id
+    add_index :users, :mention_name, unique: true
+    add_index :users, :email, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180226130714) do
+ActiveRecord::Schema.define(version: 20180226145852) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -63,6 +63,9 @@ ActiveRecord::Schema.define(version: 20180226130714) do
     t.string "email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "mention_name"
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["mention_name"], name: "index_users_on_mention_name", unique: true
   end
 
   add_foreign_key "post_likes", "posts"

--- a/spec/apis/api/v1/user/likes_spec.rb
+++ b/spec/apis/api/v1/user/likes_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+module API
+  module V1
+    module Post
+      RSpec.describe Likes, type: :request do
+        context 'ユーザーがいる場合' do
+          let!(:user) { create(:user) }
+          let!(:post) { create(:post) }
+
+          describe 'GET /:mention_name/post_likes' do
+            # TODO: 現在は投稿に関する「いいね！」だけを考えているが、
+            #       チャットに対しての「いいね！」も考えるようになったら、
+            #       current_user.chat_likesも足すようにする。
+            let!(:post_likes) { create_list(:post_like, 5, user: user, post: post) }
+            let(:path)       { "/api/v1/#{user.mention_name}/post_likes" }
+
+            before do
+              get path
+            end
+
+            it 'ステータス200(OK)が返ってくること' do
+              expect(response.status).to eq 200
+            end
+
+            it 'ユーザーの「いいね！」一覧がjsonで返ってくる' do
+              actual   = JSON.parse(response.body)
+              expected = JSON.parse(post_likes.to_json)
+              expect(actual).to include_json expected
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -10,7 +10,8 @@
 
 FactoryBot.define do
   factory :user do
-    email { Faker::Internet.email }
+    mention_name { Faker::Lorem.characters(5) }
+    email        { Faker::Internet.email }
 
     factory :user_with_profile do
       association :profile, factory: :profile


### PR DESCRIPTION
## ストーリー
なし

## 概要
フロント側のユーザーランキングの表示データをバックエンドのAPIたたいて用意したいと思った時にそのAPIがなかったので実装した。

指定したmention_nameを持つユーザーの「いいね！」一覧を返すAPIになっている。