### PR TITLE
serializerを名前空間で分けた。

### DIFF
--- a/app/apis/api/v1/posts.rb
+++ b/app/apis/api/v1/posts.rb
@@ -6,7 +6,7 @@ module API
 
       helpers do
         def posts_with_user
-          ::Post.all
+          JSON.parse(ActiveModel::Serializer::CollectionSerializer.new(::Post.all, serializer: API::V1::PostSerializer).to_json)
         end
       end
 

--- a/app/apis/api/v1/tags.rb
+++ b/app/apis/api/v1/tags.rb
@@ -6,7 +6,7 @@ module API
 
       helpers do
         def tags_with_post_taggings
-          ::Tag.all
+          JSON.parse(ActiveModel::Serializer::CollectionSerializer.new(::Tag.all, serializer: API::V1::TagSerializer).to_json)
         end
       end
 

--- a/app/apis/api/v1/users.rb
+++ b/app/apis/api/v1/users.rb
@@ -7,7 +7,7 @@ module API
         end
 
         def users_with_profile
-          ::User.all
+          JSON.parse(ActiveModel::Serializer::CollectionSerializer.new(::User.all, serializer: API::V1::UserSerializer).to_json)
         end
       end
 

--- a/app/serializers/api/v1/post_serializer.rb
+++ b/app/serializers/api/v1/post_serializer.rb
@@ -1,0 +1,14 @@
+class API::V1::PostSerializer < PostSerializer
+  attributes :revision, :post_likings_count
+
+  has_many :post_likings
+  belongs_to :user
+
+  def revision
+    object.revisions.find(object.newest_revision_id)
+  end
+
+  def post_likings_count
+    object.post_likings.count
+  end
+end

--- a/app/serializers/api/v1/tag_serializer.rb
+++ b/app/serializers/api/v1/tag_serializer.rb
@@ -1,0 +1,9 @@
+class API::V1::TagSerializer < TagSerializer
+  attributes :post_taggings_count
+
+  has_many :post_taggings
+
+  def post_taggings_count
+    object.post_taggings.size
+  end
+end

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -1,0 +1,10 @@
+class API::V1::UserSerializer < UserSerializer
+  attributes :post_likings_count
+
+  has_one :profile
+  has_many :post_likings
+
+  def post_likings_count
+    object.post_likings.size
+  end
+end

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -10,16 +10,5 @@
 #
 
 class PostSerializer < ActiveModel::Serializer
-  attributes :id, :user_id, :newest_revision_id, :created_at, :updated_at, :revision, :post_likings_count
-
-  has_many :post_likings
-  belongs_to :user
-
-  def revision
-    object.revisions.find(object.newest_revision_id)
-  end
-
-  def post_likings_count
-    object.post_likings.count
-  end
+  attributes :id, :user_id, :newest_revision_id, :created_at, :updated_at
 end

--- a/app/serializers/tag_serializer.rb
+++ b/app/serializers/tag_serializer.rb
@@ -9,11 +9,5 @@
 #
 
 class TagSerializer < ActiveModel::Serializer
-  attributes :id, :name, :created_at, :updated_at, :post_taggings_count
-
-  has_many :post_taggings
-
-  def post_taggings_count
-    object.post_taggings.size
-  end
+  attributes :id, :name, :created_at, :updated_at
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -10,12 +10,5 @@
 #
 
 class UserSerializer < ActiveModel::Serializer
-  attributes :id, :email, :mention_name, :created_at, :updated_at, :post_likings_count
-
-  has_one :profile
-  has_many :post_likings
-
-  def post_likings_count
-    object.post_likings.size
-  end
+  attributes :id, :email, :mention_name, :created_at, :updated_at
 end


### PR DESCRIPTION
## ストーリー
なし

## 概要
serializerを名前空間で分けるようにした。
associationが必要なAPIそうでないAPIで使うserializerをわけれるようにしたが管理しやすいため

## その他
その都度、serializerは追加していく。