### PR TITLE
[#157175429]タグフードの作り込み[フロントエンド]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,3 +67,5 @@ gem 'active_model_serializers'
 gem 'kaminari'
 gem 'kaminari-grape'
 gem 'grape-kaminari'
+
+gem 'active_model_serializers-matchers', github: 'BrainCheck/active_model_serializers-matchers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/BrainCheck/active_model_serializers-matchers.git
+  revision: 25cd66e0b431ca4c6631f3445446585cc917efef
+  specs:
+    active_model_serializers-matchers (0.5.2)
+      active_model_serializers (>= 0.8.1)
+      rspec (~> 3.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -194,6 +202,10 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    rspec (3.7.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
     rspec-core (3.7.1)
       rspec-support (~> 3.7.0)
     rspec-expectations (3.7.0)
@@ -263,6 +275,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers
+  active_model_serializers-matchers!
   annotate
   byebug
   database_rewinder

--- a/app/apis/api/v1/all/posts.rb
+++ b/app/apis/api/v1/all/posts.rb
@@ -6,12 +6,17 @@ module API
         include Grape::ActiveModelSerializers
         include Grape::Kaminari
 
+        # 参考
+        # https://stackoverflow.com/questions/35344117/why-does-session-doesnt-work-in-grape-rails
+        use ActionDispatch::Session::CookieStore, key: 'user_id'
+        helpers API::V1::CurrentUser::Helpers::SessionHelper
+
         helpers do
           # userとrevisionとpost_likingsを持つ
           def serialized_posts
             resource = ActiveModelSerializers::SerializableResource.new(
               paginated_posts,
-              each_serializer: API::V1::PostSerializer,
+              each_serializer: serializer,
               adapter: :json_api,
               serialization_context: ActiveModelSerializers::SerializationContext.new(request)
             )
@@ -19,13 +24,40 @@ module API
           end
 
           def paginated_posts
-            paginate(Post.all)
+            paginate(filtered_posts)
+          end
+
+          def filtered_posts
+            if post_params[:current_user_following_tags]
+              current_user_tag_ids = current_user.tag_followings.pluck(:tag_id)
+              API::V1::All::Post.where_filtered_by_tags(current_user_tag_ids)
+            else
+              API::V1::All::Post.all
+            end
+          end
+
+          def serializer
+            if post_params[:current_user_following_tags]
+              CurrentUserFollowingTagsPostSerializer
+            else
+              PostSerializer
+            end
+          end
+
+          def post_params
+            ActionController::Parameters.new(params).permit(
+              :page,
+              :per_page,
+              :offset,
+              :current_user_following_tags
+            )
           end
 
           params :query_params do
             optional :page,     type: Integer, documentation: { params_type: 'query' }
             optional :per_page, type: Integer, documentation: { params_type: 'query' }
             optional :offset,   type: Integer, documentation: { params_type: 'query' }
+            optional :current_user_following_tags, type: Boolean, documentation: { params_type: 'query' }
           end
         end
 

--- a/app/models/api/v1/all/post.rb
+++ b/app/models/api/v1/all/post.rb
@@ -6,4 +6,7 @@ class API::V1::All::Post < Post
   accepts_nested_attributes_for :revisions
 
   has_many :post_likings, class_name: 'PostLiking', dependent: :destroy
+  has_many :post_taggings, class_name: 'PostTagging', dependent: :destroy
+
+  scope :where_filtered_by_tags, ->(tag_ids) { where(id: API::V1::All::PostTagging.filtered_post_ids_by(tag_ids)) }
 end

--- a/app/models/api/v1/all/post_tagging.rb
+++ b/app/models/api/v1/all/post_tagging.rb
@@ -1,3 +1,10 @@
 class API::V1::All::PostTagging < PostTagging
   belongs_to :tag, optional: true
+  belongs_to :post, optional: true
+
+  class << self
+    def filtered_post_ids_by(tag_ids = [])
+      where(tag_id: tag_ids).pluck(:post_id).uniq
+    end
+  end
 end

--- a/app/models/api/v1/current_user/all/post.rb
+++ b/app/models/api/v1/current_user/all/post.rb
@@ -1,9 +1,8 @@
 class API::V1::CurrentUser::All::Post < Post
   # https://qiita.com/junara/items/ca6f65d2f2a27f185f0e
   belongs_to :user, optional: true
+  has_many :post_taggings, class_name: 'API::V1::CurrentUser::All::PostTagging', dependent: :destroy
 
   has_many :revisions, dependent: :destroy
   accepts_nested_attributes_for :revisions
-
-  has_many :post_taggings, dependent: :destroy
 end

--- a/app/models/api/v1/current_user/all/tag.rb
+++ b/app/models/api/v1/current_user/all/tag.rb
@@ -1,0 +1,2 @@
+class API::V1::CurrentUser::All::Tag < Tag
+end

--- a/app/models/api/v1/current_user/all/tag_following.rb
+++ b/app/models/api/v1/current_user/all/tag_following.rb
@@ -1,0 +1,4 @@
+class API::V1::CurrentUser::All::TagFollowing < TagFollowing
+  belongs_to :user
+  belongs_to :tag
+end

--- a/app/models/api/v1/current_user/all/user.rb
+++ b/app/models/api/v1/current_user/all/user.rb
@@ -1,6 +1,8 @@
 class API::V1::CurrentUser::All::User < User
   has_many :posts, dependent: :destroy
+  has_many :post_taggings, class_name: 'API::V1::CurrentUser::All::PostTagging', through: :posts
   # API::V1::CurrentUser::Settingスコープのカレントユーザーで使用されるassociation
   has_one :profile, dependent: :destroy
   has_many :post_likings, dependent: :destroy
+  has_many :tag_followings, dependent: :destroy
 end

--- a/app/models/tag_following.rb
+++ b/app/models/tag_following.rb
@@ -1,0 +1,4 @@
+class TagFollowing < ApplicationRecord
+  belongs_to :user
+  belongs_to :tag
+end

--- a/app/models/tag_following.rb
+++ b/app/models/tag_following.rb
@@ -1,4 +1,2 @@
 class TagFollowing < ApplicationRecord
-  belongs_to :user
-  belongs_to :tag
 end

--- a/app/serializers/api/v1/all/current_user_following_tags_post_serializer.rb
+++ b/app/serializers/api/v1/all/current_user_following_tags_post_serializer.rb
@@ -1,0 +1,31 @@
+module API
+  module V1
+    module All
+      class CurrentUserFollowingTagsPostSerializer < ::PostSerializer
+        attributes :user, :profile, :revision, :post_likings_count, :tags
+
+        has_many :post_likings
+
+        def user
+          object.user
+        end
+
+        def profile
+          object.user.profile
+        end
+
+        def revision
+          object.revisions.find(object.newest_revision_id)
+        end
+
+        def post_likings_count
+          object.post_likings.count
+        end
+
+        def tags
+          API::V1::All::Tag.where(id: object.post_taggings.pluck(:tag_id))
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/api/v1/all/post_liking_serializer.rb
+++ b/app/serializers/api/v1/all/post_liking_serializer.rb
@@ -1,0 +1,9 @@
+module API
+  module V1
+    module All
+      class PostLikingSerializer < ::PostLikingSerializer
+        attributes :id, :user_id, :post_id, :from_user_id, :created_at, :updated_at
+      end
+    end
+  end
+end

--- a/app/serializers/api/v1/all/post_serializer.rb
+++ b/app/serializers/api/v1/all/post_serializer.rb
@@ -1,0 +1,27 @@
+module API
+  module V1
+    module All
+      class PostSerializer < ::PostSerializer
+        attributes :user, :profile, :revision, :post_likings_count
+
+        has_many :post_likings
+
+        def user
+          object.user
+        end
+
+        def profile
+          object.user.profile
+        end
+
+        def revision
+          object.revisions.find(object.newest_revision_id)
+        end
+
+        def post_likings_count
+          object.post_likings.count
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20180421053353_create_tag_followings.rb
+++ b/db/migrate/20180421053353_create_tag_followings.rb
@@ -1,0 +1,10 @@
+class CreateTagFollowings < ActiveRecord::Migration[5.1]
+  def change
+    create_table :tag_followings do |t|
+      t.references :user, foreign_key: true, null: false
+      t.references :tag, foreign_key: true,  null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180304040852) do
+ActiveRecord::Schema.define(version: 20180421053353) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -68,6 +68,15 @@ ActiveRecord::Schema.define(version: 20180304040852) do
     t.index ["post_id"], name: "index_revisions_on_post_id"
   end
 
+  create_table "tag_followings", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "tag_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["tag_id"], name: "index_tag_followings_on_tag_id"
+    t.index ["user_id"], name: "index_tag_followings_on_user_id"
+  end
+
   create_table "tags", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
@@ -90,4 +99,6 @@ ActiveRecord::Schema.define(version: 20180304040852) do
   add_foreign_key "posts", "users"
   add_foreign_key "profiles", "users"
   add_foreign_key "revisions", "posts"
+  add_foreign_key "tag_followings", "tags"
+  add_foreign_key "tag_followings", "users"
 end

--- a/frontend/src/api/__test__/factories/all/current_user_following_tags_posts.js
+++ b/frontend/src/api/__test__/factories/all/current_user_following_tags_posts.js
@@ -1,0 +1,304 @@
+export default {
+  "data": [
+    {
+      "id": "1",
+      "type": "api-v1-all-posts",
+      "attributes": {
+        "user-id": 1,
+        "newest-revision-id": 5,
+        "created-at": "2018-03-03T12:28:30.138Z",
+        "updated-at": "2018-03-03T12:28:30.219Z",
+        "user": {
+          "id": 1,
+          "email": "rosario.funk@marvinpurdy.co",
+          "created_at": "2018-03-03T12:28:30.098Z",
+          "updated_at": "2018-03-03T12:28:30.098Z",
+          "mention_name": "0gm98"
+        },
+        "profile": {
+          "id": 1,
+          "user_id": 1,
+          "name": "Kristopher Conroy",
+          "kana": "Harley Dach II",
+          "organization": "Watsica-Lind",
+          "introduction": "jsvvy7gvo71jxdqiqp40pk713wmyor33w7zz67hf0qgggtms6jptdt031l5ss3l1gl1v7z6gshvj72cg",
+          "image": "#<File:0x007fe851de23d0>",
+          "created_at": "2018-03-03T12:28:31.480Z",
+          "updated_at": "2018-03-03T12:28:31.480Z"
+        },
+        "revision": {
+          "id": 5,
+          "post_id": 1,
+          "title": "fs01xn60",
+          "summary": "nsykn4mq",
+          "goal": "fprv0vei",
+          "event_url": "ikd79w32",
+          "body": "gdxllsd5",
+          "slide_url": "l8ihej1b",
+          "created_at": "2018-03-03T12:28:30.196Z",
+          "updated_at": "2018-03-03T12:28:30.196Z",
+          "comment": "yyt7awo0"
+        },
+        "post-likings-count": 10,
+        "tags": [
+          {
+            "id": 1,
+            "name": "Python",
+            "created_at": "2018-03-03T12:28:31.554Z",
+            "updated_at": "2018-03-03T12:28:31.554Z"
+          },
+          {
+            "id": 2,
+            "name": "JavaScript",
+            "created_at": "2018-03-03T12:28:31.557Z",
+            "updated_at": "2018-03-03T12:28:31.557Z"
+          },
+          {
+            "id": 3,
+            "name": "Ruby",
+            "created_at": "2018-03-03T12:28:31.559Z",
+            "updated_at": "2018-03-03T12:28:31.559Z"
+          },
+          {
+            "id": 4,
+            "name": "AWS",
+            "created_at": "2018-03-03T12:28:31.561Z",
+            "updated_at": "2018-03-03T12:28:31.561Z"
+          },
+          {
+            "id": 5,
+            "name": "Android",
+            "created_at": "2018-03-03T12:28:31.562Z",
+            "updated_at": "2018-03-03T12:28:31.562Z"
+          },
+          {
+            "id": 6,
+            "name": "Docker",
+            "created_at": "2018-03-03T12:28:31.564Z",
+            "updated_at": "2018-03-03T12:28:31.564Z"
+          },
+          {
+            "id": 7,
+            "name": "Swift",
+            "created_at": "2018-03-03T12:28:31.565Z",
+            "updated_at": "2018-03-03T12:28:31.565Z"
+          },
+          {
+            "id": 8,
+            "name": "iOS",
+            "created_at": "2018-03-03T12:28:31.567Z",
+            "updated_at": "2018-03-03T12:28:31.567Z"
+          },
+          {
+            "id": 9,
+            "name": "Rails",
+            "created_at": "2018-03-03T12:28:31.570Z",
+            "updated_at": "2018-03-03T12:28:31.570Z"
+          },
+          {
+            "id": 10,
+            "name": "PHP",
+            "created_at": "2018-03-03T12:28:31.571Z",
+            "updated_at": "2018-03-03T12:28:31.571Z"
+          }
+        ]
+      },
+      "relationships": {
+        "post-likings": {
+          "data": [
+            {
+              "id": "1",
+              "type": "api-v1-all-post-likings"
+            },
+            {
+              "id": "2",
+              "type": "api-v1-all-post-likings"
+            },
+            {
+              "id": "3",
+              "type": "api-v1-all-post-likings"
+            },
+            {
+              "id": "4",
+              "type": "api-v1-all-post-likings"
+            },
+            {
+              "id": "5",
+              "type": "api-v1-all-post-likings"
+            },
+            {
+              "id": "6",
+              "type": "api-v1-all-post-likings"
+            },
+            {
+              "id": "7",
+              "type": "api-v1-all-post-likings"
+            },
+            {
+              "id": "8",
+              "type": "api-v1-all-post-likings"
+            },
+            {
+              "id": "9",
+              "type": "api-v1-all-post-likings"
+            },
+            {
+              "id": "10",
+              "type": "api-v1-all-post-likings"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "2",
+      "type": "api-v1-all-posts",
+      "attributes": {
+        "user-id": 1,
+        "newest-revision-id": 10,
+        "created-at": "2018-03-03T12:28:30.221Z",
+        "updated-at": "2018-03-03T12:28:30.241Z",
+        "user": {
+          "id": 1,
+          "email": "rosario.funk@marvinpurdy.co",
+          "created_at": "2018-03-03T12:28:30.098Z",
+          "updated_at": "2018-03-03T12:28:30.098Z",
+          "mention_name": "0gm98"
+        },
+        "profile": {
+          "id": 1,
+          "user_id": 1,
+          "name": "Kristopher Conroy",
+          "kana": "Harley Dach II",
+          "organization": "Watsica-Lind",
+          "introduction": "jsvvy7gvo71jxdqiqp40pk713wmyor33w7zz67hf0qgggtms6jptdt031l5ss3l1gl1v7z6gshvj72cg",
+          "image": "#<File:0x007fe851de23d0>",
+          "created_at": "2018-03-03T12:28:31.480Z",
+          "updated_at": "2018-03-03T12:28:31.480Z"
+        },
+        "revision": {
+          "id": 10,
+          "post_id": 2,
+          "title": "leadznnd",
+          "summary": "sujim2m7",
+          "goal": "7wx5k1u4",
+          "event_url": "csh4ikpk",
+          "body": "dvj4jra7",
+          "slide_url": "34t69hm7",
+          "created_at": "2018-03-03T12:28:30.231Z",
+          "updated_at": "2018-03-03T12:28:30.231Z",
+          "comment": "gt07h06x"
+        },
+        "post-likings-count": 10,
+        "tags": [
+          {
+            "id": 1,
+            "name": "Python",
+            "created_at": "2018-03-03T12:28:31.554Z",
+            "updated_at": "2018-03-03T12:28:31.554Z"
+          },
+          {
+            "id": 2,
+            "name": "JavaScript",
+            "created_at": "2018-03-03T12:28:31.557Z",
+            "updated_at": "2018-03-03T12:28:31.557Z"
+          },
+          {
+            "id": 3,
+            "name": "Ruby",
+            "created_at": "2018-03-03T12:28:31.559Z",
+            "updated_at": "2018-03-03T12:28:31.559Z"
+          },
+          {
+            "id": 4,
+            "name": "AWS",
+            "created_at": "2018-03-03T12:28:31.561Z",
+            "updated_at": "2018-03-03T12:28:31.561Z"
+          },
+          {
+            "id": 5,
+            "name": "Android",
+            "created_at": "2018-03-03T12:28:31.562Z",
+            "updated_at": "2018-03-03T12:28:31.562Z"
+          },
+          {
+            "id": 6,
+            "name": "Docker",
+            "created_at": "2018-03-03T12:28:31.564Z",
+            "updated_at": "2018-03-03T12:28:31.564Z"
+          },
+          {
+            "id": 7,
+            "name": "Swift",
+            "created_at": "2018-03-03T12:28:31.565Z",
+            "updated_at": "2018-03-03T12:28:31.565Z"
+          },
+          {
+            "id": 8,
+            "name": "iOS",
+            "created_at": "2018-03-03T12:28:31.567Z",
+            "updated_at": "2018-03-03T12:28:31.567Z"
+          },
+          {
+            "id": 9,
+            "name": "Rails",
+            "created_at": "2018-03-03T12:28:31.570Z",
+            "updated_at": "2018-03-03T12:28:31.570Z"
+          },
+          {
+            "id": 10,
+            "name": "PHP",
+            "created_at": "2018-03-03T12:28:31.571Z",
+            "updated_at": "2018-03-03T12:28:31.571Z"
+          }
+        ]
+      },
+      "relationships": {
+        "post-likings": {
+          "data": [
+            {
+              "id": "11",
+              "type": "api-v1-all-post-likings"
+            },
+            {
+              "id": "12",
+              "type": "api-v1-all-post-likings"
+            },
+            {
+              "id": "13",
+              "type": "api-v1-all-post-likings"
+            },
+            {
+              "id": "14",
+              "type": "api-v1-all-post-likings"
+            },
+            {
+              "id": "15",
+              "type": "api-v1-all-post-likings"
+            },
+            {
+              "id": "16",
+              "type": "api-v1-all-post-likings"
+            },
+            {
+              "id": "17",
+              "type": "api-v1-all-post-likings"
+            },
+            {
+              "id": "18",
+              "type": "api-v1-all-post-likings"
+            },
+            {
+              "id": "19",
+              "type": "api-v1-all-post-likings"
+            },
+            {
+              "id": "20",
+              "type": "api-v1-all-post-likings"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/frontend/src/api/decorator/__test__/all/current_user_following_tags_post_decorator.spec.js
+++ b/frontend/src/api/decorator/__test__/all/current_user_following_tags_post_decorator.spec.js
@@ -6,6 +6,14 @@ var moment = require('moment')
 describe('CurrentUserFollowingTagsPostDecorator', () => {
   var postDecorator = new CurrentUserFollowingTagsPostDecorator(factoryPost.data[0])
 
+  describe('.data()', () => {
+    const expected = { "organization": "Watsica-Lind", "summary": "nsykn4mq", "tag": "Python", "title": "fs01xn60", "when": "2 months ago" }
+    const actual = postDecorator.data()
+    it('デコレータされたデータが連想配列で返ってくる', () => {
+      expect(actual).toEqual(expected)
+    })
+  })
+
   describe('.tag()', () => {
     const expected = factoryPost.data[0].attributes.tags[0].name
     const actual = postDecorator.tag()

--- a/frontend/src/api/decorator/__test__/all/current_user_following_tags_post_decorator.spec.js
+++ b/frontend/src/api/decorator/__test__/all/current_user_following_tags_post_decorator.spec.js
@@ -1,0 +1,49 @@
+import CurrentUserFollowingTagsPostDecorator from '@/api/decorator/all/current_user_following_tags_post_decorator'
+import factoryPost from '@/api/__test__/factories/all/current_user_following_tags_posts'
+
+var moment = require('moment')
+
+describe('CurrentUserFollowingTagsPostDecorator', () => {
+  var postDecorator = new CurrentUserFollowingTagsPostDecorator(factoryPost.data[0])
+
+  describe('.tag()', () => {
+    const expected = factoryPost.data[0].attributes.tags[0].name
+    const actual = postDecorator.tag()
+    it('投稿についた最初のタグが習得できること', () => {
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  describe('.when()', () => {
+    const created_at = factoryPost.data[0].attributes.revision.created_at
+    const expected = moment(created_at).fromNow()
+    const actual = postDecorator.when()
+    it('投稿された日時が取得できること', () => {
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  describe('.title()', () => {
+    const expected = factoryPost.data[0].attributes.revision.title
+    const actual = postDecorator.title()
+    it('投稿のタイトルが取得できること', () => {
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  describe('.organization()', () => {
+    const expected = factoryPost.data[0].attributes.profile.organization
+    const actual = postDecorator.organization()
+    it('投稿者の会社名が取得できること', () => {
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  describe('.summary()', () => {
+    const expected = factoryPost.data[0].attributes.revision.summary
+    const actual = postDecorator.summary()
+    it('投稿の要約が取得できること', () => {
+      expect(actual).toEqual(expected)
+    })
+  })
+})

--- a/frontend/src/api/decorator/__test__/all/post_decorator.spec.js
+++ b/frontend/src/api/decorator/__test__/all/post_decorator.spec.js
@@ -6,6 +6,14 @@ var moment = require('moment')
 describe('PostDecorator', () => {
   var postDecorator = new PostDecorator(factoryPost.data[0])
 
+  describe('.data()', () => {
+    const expected = { "likes": 10, "organization": "Watsica-Lind", "summary": "nsykn4mq", "title": "fs01xn60", "when": "2 months ago", "who": "0gm98" }
+    const actual = postDecorator.data()
+    it ('デコレータされたデータが連想配列で返ってくる', () => {
+      expect(actual).toEqual(expected)
+    })
+  })
+
   describe('.who()', () => {
     const expected = factoryPost.data[0].attributes.user.mention_name
     const actual = postDecorator.who()

--- a/frontend/src/api/decorator/all/current_user_following_tags_post_decorator.js
+++ b/frontend/src/api/decorator/all/current_user_following_tags_post_decorator.js
@@ -8,6 +8,16 @@ export default class CurrentUserFollowingTagsPostDecorator {
     this.resource = resource
   }
 
+  data() {
+    return {
+      tag: this.tag(),
+      when: this.when(),
+      title: this.title(),
+      organization: this.organization(),
+      summary: this.summary()
+    }
+  }
+
   tag() {
     return this.resource.attributes.tags[0].name
   }

--- a/frontend/src/api/decorator/all/current_user_following_tags_post_decorator.js
+++ b/frontend/src/api/decorator/all/current_user_following_tags_post_decorator.js
@@ -1,0 +1,32 @@
+var moment = require('moment')
+
+// @flow
+export default class CurrentUserFollowingTagsPostDecorator {
+  resource: Object
+
+  constructor (resource: Object) {
+    this.resource = resource
+  }
+
+  tag() {
+    return this.resource.attributes.tags[0].name
+  }
+
+  when() {
+    var created_at = this.resource.attributes.revision.created_at
+    var formatted_created_at = moment(created_at).fromNow()
+    return formatted_created_at
+  }
+
+  title() {
+    return this.resource.attributes.revision.title
+  }
+
+  organization() {
+    return this.resource.attributes.profile.organization
+  }
+
+  summary() {
+    return this.resource.attributes.revision.summary
+  }
+}

--- a/frontend/src/api/decorator/all/post_decorator.js
+++ b/frontend/src/api/decorator/all/post_decorator.js
@@ -8,6 +8,17 @@ export default class PostDecorator {
     this.resource = resource
   }
 
+  data() {
+    return {
+      who: this.who(),
+      when: this.when(),
+      likes: this.likes(),
+      title: this.title(),
+      organization: this.organization(),
+      summary: this.summary()
+    }
+  }
+
   who() {
     return this.resource.attributes.user.mention_name
   }

--- a/frontend/src/components/__test__/atoms/pagination/Pagination.spec.js
+++ b/frontend/src/components/__test__/atoms/pagination/Pagination.spec.js
@@ -1,0 +1,20 @@
+import Vuex from 'vuex'
+import { mount, createLocalVue } from 'vue-test-utils'
+import Paginaiton from '@/components/atoms/pagination/Pagination.vue'
+
+const localVue = createLocalVue()
+localVue.use(Vuex)
+
+describe('Pagination.vue', () => {
+  it('propsのテスト', () => {
+    var myMock = jest.fn()
+    const wrapper = mount(Paginaiton,{ localVue,
+      propsData: {
+        pageCount: 5,
+        clickHander: myMock
+      }
+    })
+    expect(wrapper.props().pageCount).toBe(5)
+    expect(wrapper.props().clickHander).toEqual(myMock)
+  })
+})

--- a/frontend/src/components/__test__/organisms/table/TagFeedTable.spec.js
+++ b/frontend/src/components/__test__/organisms/table/TagFeedTable.spec.js
@@ -1,0 +1,8 @@
+import Vuex from 'vuex'
+import { shallow, createLocalVue } from 'vue-test-utils'
+
+describe('TagFeedTable.vue', () => {
+  it('ダミーテスト', () => {
+    expect(true).toEqual(true)
+  })
+})

--- a/frontend/src/components/__test__/organisms/table/TrendTable.spec.js
+++ b/frontend/src/components/__test__/organisms/table/TrendTable.spec.js
@@ -10,7 +10,8 @@
 //     Error
 //       No script available to transform
 
-
+// 関連してそうなPR
+// https://github.com/vire/jest-vue-preprocessor/issues/49
 
 
 // import Vuex from 'vuex'

--- a/frontend/src/components/atoms/pagination/Pagination.vue
+++ b/frontend/src/components/atoms/pagination/Pagination.vue
@@ -1,0 +1,31 @@
+<template lang="pug">
+nav.pagination.is-centered(role='navigation' arial-label='pagination')
+  paginate(
+    :page-count="pageCount"
+    :margin-pages="0"
+    :page-range="5"
+    :initial-page="0"
+    :click-handler="clickHander"
+    :container-class="'pagination-list'"
+    :page-link-class="'pagination-link'"
+    :prev-link-class="'pagination-previous'"
+    :next-link-class="'pagination-next'"
+    :active-class="'is-current'"
+    :first-last-button="true"
+  )
+</template>
+
+<script>
+  export default {
+    props:{
+      pageCount:{
+        type: Number,
+        required: true
+      },
+      clickHander:{
+        type: Function,
+        required: true
+      }
+    }
+  }
+</script>

--- a/frontend/src/components/molecules/media_object/PostWithTagMedia.vue
+++ b/frontend/src/components/molecules/media_object/PostWithTagMedia.vue
@@ -82,6 +82,7 @@ ul
   display: inline-flex
   flex-direction: row
   align-items: stretch
+  width: 100%
 
 
 .m-post-with-tag-media-left

--- a/frontend/src/components/organisms/table/TagFeedTable.vue
+++ b/frontend/src/components/organisms/table/TagFeedTable.vue
@@ -1,52 +1,104 @@
 <template lang="pug">
 .hero
   tag-feed-table-title
-  post-with-tag-media(:profile-image-src='require("@/assets/home/user/aimerald.png")',
-       :tag-image-src='require("@/assets/home/tag/Ruby.jpg")',
-       tag='Ruby', when='15 minutes ago',
-       title='rubyでLispの処理系を書いた話',
-       organization='株式会社Aiming',
-       summary='Lispっていいですよね。何と言ってもインタプリタシンプルですよね。これrubyでも書けそうな気がしたんでかいてみました。少しでもLispに興味を盛ってくれる人が増えたら嬉しいなと思って作ってみました。')
-  post-with-tag-media(:profile-image-src='require("@/assets/home/user/YumaInaura.png")',
-       :tag-image-src='require("@/assets/home/tag/Rails.jpg")',
-       tag='Rails', when='1 hours ago',
-       title='瞑想がプログラマに与える効果に関して',
-       organization='株式会社Aiming',
-       summary='Googleも取り入れている瞑想意外と知らない瞑想の効果そんな瞑想の効果を1年間自分でやってみた経験を踏まえ話してみたいと思います。この資料をみて瞑想を生活習慣に取り入れてくれる人が増えたらいいな')
-  post-with-tag-media(:profile-image-src='require("@/assets/home/user/KojiMiyake.png")',
-       :tag-image-src='require("@/assets/home/tag/PHP.jpg")',
-       tag='PHP', when='2 hours ago',
-       title='PHPを学び現場に入るまで',
-       organization='株式会社リクルートマーケティングパートナーズ',
-       summary='現在、PHPを学ぶためにはPHPチュートリアルをこなしたり書籍などを利用すると思われる。しかし実際の現場で開発すると、アプリケーションの構成やPHPの罠に戸惑う事がある。本発表ではPHP初学者が現場で開発する時に感じるであろうギャップをいくつか紹介する。')
-  post-with-tag-media(:profile-image-src='require("@/assets/home/user/yuemori.png")',
-       :tag-image-src='require("@/assets/home/tag/Docker.png")',
-       tag='Docker', when='1 week ago',
-       title='Rails on Dockerとの戦い',
-       organization='株式会社Aiming',
-       summary='Docker使っていますか？Rails on Dockerの事例は増えつつありますが、導入方法や構成について語られる事が多く、苦しみやすい・難しい点について語られることはあまりないように思います。今回はRuby/RailsでDockerを使ってきて戦った点とその解決方法について話します。')
-  post-with-tag-media(:profile-image-src='require("@/assets/home/user/skuroki.jpg")',
-       :tag-image-src='require("@/assets/home/tag/JavaScript.jpg")',
-       tag='JavaScript', when='1 months ago',
-       title='新人プログラマとペアプロしてわかったこと',
-       organization='株式会社Aiming',
-       summary='毎年、新しいメンバーが参画し、ペアプロで指導しています。今まで色んな人とペアプロしてきてわかったことがありま  す。その中でコツというかわかった事があったので資料にしてみました。背景知識がない人に以下に教えるか？相手の性格に焦点を当てて語りたいと思います。')
-  post-with-tag-media(:profile-image-src='require("@/assets/home/user/yukihirop.jpg")',
-       tagImageSrc='https://bulma.io/images/placeholders/64x64.png',
-       tag='WEB', when='1 months ago',
-       title='OnePageというWEBサービスを作った話',
-       organization='株式会社Aiming',
-       summary='OnePageとは一言でいれば、プログラマのためのプレゼン資料共有ツールです。完成したプレゼンの資料を共有するのではなく、計画書(ブレスト)を共有し互いにレビューすることで構造的プレゼン資料を作成できるように習慣づけるサービスです。')
+  span(v-for='(post, index) in posts')
+    post-with-tag-media(:profile-image-src='profileImageSrcs[index]',
+                        :tag-image-src='tagImageSrcs[index]',
+                        :tag="post.tag",
+                        :when="post.when",
+                        :title="post.title",
+                        :organization="post.organization",
+                        :summary="post.summary"
+    )
+  br
+  nav.pagination.is-centered(role='navigation' arial-label='pagination')
+    paginate(
+      :page-count="headers['page-count']"
+      :margin-pages="0"
+      :page-range="5"
+      :initial-page="0"
+      :click-handler="fetchPosts"
+      :container-class="'pagination-list'"
+      :page-link-class="'pagination-link'"
+      :prev-link-class="'pagination-previous'"
+      :next-link-class="'pagination-next'"
+      :active-class="'is-current'"
+      :first-last-button="true"
+    )
 </template>
 
 <script>
 import TagFeedTableTitle from '@/components/atoms/title/TagFeedTableTitle.vue'
 import PostWithTagMedia from '@/components/molecules/media_object/PostWithTagMedia.vue'
+import { post } from '@/api/index'
+import CurrentUserFollowingTagsPostDecorator from '@/api/decorator/all/current_user_following_tags_post_decorator'
 
 export default {
   components: {
     PostWithTagMedia,
     TagFeedTableTitle
+  },
+  data(){
+    return {
+      profileImageSrcs: [
+        require("@/assets/home/user/aimerald.png"),
+        require("@/assets/home/user/YumaInaura.png"),
+        require("@/assets/home/user/YumaInaura.png"),
+        require("@/assets/home/user/YumaInaura.png"),
+        require("@/assets/home/user/YumaInaura.png"),
+        require("@/assets/home/user/YumaInaura.png"),
+        require("@/assets/home/user/YumaInaura.png"),
+        require("@/assets/home/user/YumaInaura.png"),
+        require("@/assets/home/user/YumaInaura.png"),
+        require("@/assets/home/user/yukihirop.jpg")
+          ],
+      tagImageSrcs: [],
+      posts: [],
+      headers: {}
+    }
+  },
+  mounted(){
+    this.fetchPosts()
+  },
+  methods: {
+    fetchPosts(pageNum){
+      this.headers = {}
+      this.posts = []
+      post.index_at_page(this.customize_params(pageNum)).then(response => {
+        this.parseResponseHeaders(response)
+        this.parseResponseData(response)
+      }).catch(error => {
+        console.error(error)
+      })
+    },
+    parseResponseData(response){
+      response.data["data"].forEach( post => {
+        var postDecorator = new CurrentUserFollowingTagsPostDecorator(post)
+        var result = {
+          tag: postDecorator.tag(),
+          when: postDecorator.when(),
+          title: postDecorator.title(),
+          organization: postDecorator.organization(),
+          summary: postDecorator.summary()
+        }
+        this.posts.push(result)
+        this.createTagImageSrcs(result)
+      })
+    },
+    parseResponseHeaders(response){
+      var headers = response.headers
+      this.headers['page-count'] = headers['x-total-pages']
+    },
+    customize_params(pageNum){
+      var params = typeof pageNum !== 'undefined' ? '\?page=' + pageNum : null
+      var customize_params = params !== null ? params + '&current_user_following_tags=true' : '\?current_user_following_tags=true'
+      return customize_params
+    },
+    // ゆくゆくは、Amazon S3から画像を習得するようにしたい。
+    createTagImageSrcs(post){
+      var tagImageSrc = require("@/assets/home/tag/" + post.tag + ".jpg")
+      this.tagImageSrcs.push(tagImageSrc)
+    }
   }
 }
 </script>

--- a/frontend/src/components/organisms/table/TagFeedTable.vue
+++ b/frontend/src/components/organisms/table/TagFeedTable.vue
@@ -63,15 +63,8 @@ export default {
     parseResponseData(response){
       response.data["data"].forEach( post => {
         var postDecorator = new CurrentUserFollowingTagsPostDecorator(post)
-        var result = {
-          tag: postDecorator.tag(),
-          when: postDecorator.when(),
-          title: postDecorator.title(),
-          organization: postDecorator.organization(),
-          summary: postDecorator.summary()
-        }
-        this.posts.push(result)
-        this.createTagImageSrcs(result)
+        this.posts.push(postDecorator.data())
+        this.createTagImageSrcs(postDecorator.data())
       })
     },
     parseResponseHeaders(response){

--- a/frontend/src/components/organisms/table/TagFeedTable.vue
+++ b/frontend/src/components/organisms/table/TagFeedTable.vue
@@ -11,32 +11,21 @@
                         :summary="post.summary"
     )
   br
-  nav.pagination.is-centered(role='navigation' arial-label='pagination')
-    paginate(
-      :page-count="headers['page-count']"
-      :margin-pages="0"
-      :page-range="5"
-      :initial-page="0"
-      :click-handler="fetchPosts"
-      :container-class="'pagination-list'"
-      :page-link-class="'pagination-link'"
-      :prev-link-class="'pagination-previous'"
-      :next-link-class="'pagination-next'"
-      :active-class="'is-current'"
-      :first-last-button="true"
-    )
+  pagination(:page-count="headers['page-count']", :click-hander="fetchPosts")
 </template>
 
 <script>
 import TagFeedTableTitle from '@/components/atoms/title/TagFeedTableTitle.vue'
 import PostWithTagMedia from '@/components/molecules/media_object/PostWithTagMedia.vue'
+import Pagination from '@/components/atoms/pagination/Pagination.vue'
 import { post } from '@/api/index'
 import CurrentUserFollowingTagsPostDecorator from '@/api/decorator/all/current_user_following_tags_post_decorator'
 
 export default {
   components: {
     PostWithTagMedia,
-    TagFeedTableTitle
+    TagFeedTableTitle,
+    Pagination
   },
   data(){
     return {

--- a/frontend/src/components/organisms/table/TrendTable.vue
+++ b/frontend/src/components/organisms/table/TrendTable.vue
@@ -63,15 +63,7 @@ export default {
     parseResponseData(response){
       response.data["data"].forEach( post => {
         var postDecorator = new PostDecorator(post)
-        var result = {
-          who: postDecorator.who(),
-          when: postDecorator.when(),
-          likes: postDecorator.likes(),
-          title: postDecorator.title(),
-          organization: postDecorator.organization(),
-          summary: postDecorator.summary()
-        }
-        this.posts.push(result)
+        this.posts.push(postDecorator.data())
       })
     },
     parseResponseHeaders(response){

--- a/frontend/src/components/organisms/table/TrendTable.vue
+++ b/frontend/src/components/organisms/table/TrendTable.vue
@@ -11,32 +11,21 @@
                :summary="post.summary"
                )
   br
-  nav.pagination.is-centered(role='navigation' arial-label='pagination')
-    paginate(
-      :page-count="headers['page-count']"
-      :margin-pages="0"
-      :page-range="5"
-      :initial-page="0"
-      :click-handler="fetchPosts"
-      :container-class="'pagination-list'"
-      :page-link-class="'pagination-link'"
-      :prev-link-class="'pagination-previous'"
-      :next-link-class="'pagination-next'"
-      :active-class="'is-current'"
-      :first-last-button="true"
-    )
+  pagination(:page-count="headers['page-count']", :click-hander="fetchPosts")
 </template>
 
 <script>
 import TrendTableTitle from '@/components/atoms/title/TrendTableTitle.vue'
 import PostMedia from '@/components/atoms/media_object/PostMedia.vue'
+import Pagination from '@/components/atoms/pagination/Pagination.vue'
 import { post } from '@/api/index'
 import PostDecorator from '@/api/decorator/all/post_decorator'
 
 export default {
   components: {
     TrendTableTitle,
-    PostMedia
+    PostMedia,
+    Pagination
   },
   data() {
     return {

--- a/spec/apis/api/v1/all/posts_spec.rb
+++ b/spec/apis/api/v1/all/posts_spec.rb
@@ -45,11 +45,11 @@ module API
 
         describe ' GET /posts?current_user_following_tags=true' do
           let!(:current_user_following_tags) { create_list(:api_v1_current_user_tag_following, 5, user: current_user,) }
-          let!(:posts_when_current_user_follow_tags) { create_list(:api_v1_post_with_revision_and_post_likings_and_user, 2, user: current_user) }
           let!(:filtered_posts) { API::V1::All::Post.where_filtered_by_tags(current_user_following_tags.pluck(:tag_id)) }
           let(:path) { '/api/v1/posts?current_user_following_tags=true' }
 
           before do
+            create_list(:api_v1_post_with_revision_and_post_likings_and_user, 2, user: current_user)
             # ダミーデータを用意する
             create_list(:api_v1_post_with_revision_and_post_likings_and_user, 5)
             get path

--- a/spec/apis/api/v1/all/posts_spec.rb
+++ b/spec/apis/api/v1/all/posts_spec.rb
@@ -4,17 +4,21 @@ module API
   module V1
     module All
       RSpec.describe Posts, type: :request do
+        let!(:current_user) { create(:api_v1_current_user_user) }
+
         # helpersのメソッドのモックの仕方
         # https://github.com/ruby-grape/grape/pull/397
         before do
           Grape::Endpoint.before_each do |endpoint|
-            endpoint.stub(:paginated_posts).and_return Post.all
+            @instance = endpoint
+            endpoint.stub(:current_user).and_return current_user
           end
         end
 
         after { Grape::Endpoint.before_each nil }
 
         describe 'GET /posts' do
+          let(:filtered_posts) { Post.all }
           let(:path) { '/api/v1/posts' }
 
           before do
@@ -26,14 +30,43 @@ module API
             expect(response.status).to eq 200
           end
 
-          it 'タグ一覧がjsonで返ってくる' do
+          it '投稿一覧がjsonで返ってくる' do
             resource = ActiveModelSerializers::SerializableResource.new(
-              Post.all,
-              each_serializer: API::V1::PostSerializer,
+              @instance.paginate(filtered_posts),
+              each_serializer: API::V1::All::PostSerializer,
               adapter: :json_api,
               serialization_context: ActiveModelSerializers::SerializationContext.new(request)
             )
             actual   = JSON.parse(response.body)
+            expected = JSON.parse(resource.to_json)
+            expect(actual).to eq expected
+          end
+        end
+
+        describe ' GET /posts?current_user_following_tags=true' do
+          let!(:current_user_following_tags) { create_list(:api_v1_current_user_tag_following, 5, user: current_user,) }
+          let!(:posts_when_current_user_follow_tags) { create_list(:api_v1_post_with_revision_and_post_likings_and_user, 2, user: current_user) }
+          let!(:filtered_posts) { API::V1::All::Post.where_filtered_by_tags(current_user_following_tags.pluck(:tag_id)) }
+          let(:path) { '/api/v1/posts?current_user_following_tags=true' }
+
+          before do
+            # ダミーデータを用意する
+            create_list(:api_v1_post_with_revision_and_post_likings_and_user, 5)
+            get path
+          end
+
+          it 'ステータス200(OK)が返ってくること' do
+            expect(response.status).to eq 200
+          end
+
+          it 'current_userがフォローしているタグの投稿一覧がjsonで返ってくる' do
+            resource = ActiveModelSerializers::SerializableResource.new(
+              @instance.paginate(filtered_posts),
+              each_serializer: API::V1::All::CurrentUserFollowingTagsPostSerializer,
+              adapter: :json_api,
+              serialization_context: ActiveModelSerializers::SerializationContext.new(request)
+            )
+            actual = JSON.parse(response.body)
             expected = JSON.parse(resource.to_json)
             expect(actual).to eq expected
           end

--- a/spec/factories/api/v1/all/post_taggings.rb
+++ b/spec/factories/api/v1/all/post_taggings.rb
@@ -1,4 +1,10 @@
 FactoryBot.define do
   factory :api_v1_post_tagging, class: API::V1::All::PostTagging do
+    sequence(:post_id)
+    sequence(:tag_id)
+
+    trait :with_tag do
+      tag_id { create(:api_v1_tag).id }
+    end
   end
 end

--- a/spec/factories/api/v1/all/post_taggings.rb
+++ b/spec/factories/api/v1/all/post_taggings.rb
@@ -1,10 +1,6 @@
 FactoryBot.define do
   factory :api_v1_post_tagging, class: API::V1::All::PostTagging do
-    sequence(:post_id)
-    sequence(:tag_id)
-
-    trait :with_tag do
-      tag_id { create(:api_v1_tag).id }
-    end
+    association :post, factory: :api_v1_post
+    association :tag,  factory: :api_v1_tag
   end
 end

--- a/spec/factories/api/v1/all/posts.rb
+++ b/spec/factories/api/v1/all/posts.rb
@@ -9,12 +9,14 @@ FactoryBot.define do
       transient do
         revisions_count 5
         post_likings_count 5
+        post_taggings_count 5
       end
 
       after(:create) do |post, evaluator|
         create_list(:api_v1_revision, evaluator.revisions_count, post: post)
         post.update(newest_revision_id: post.revisions.last.id)
         create_list(:api_v1_post_liking, evaluator.post_likings_count, post: post)
+        create_list(:api_v1_post_tagging, evaluator.post_taggings_count, :with_tag, post: post)
       end
     end
   end

--- a/spec/factories/api/v1/all/posts.rb
+++ b/spec/factories/api/v1/all/posts.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
         create_list(:api_v1_revision, evaluator.revisions_count, post: post)
         post.update(newest_revision_id: post.revisions.last.id)
         create_list(:api_v1_post_liking, evaluator.post_likings_count, post: post)
-        create_list(:api_v1_post_tagging, evaluator.post_taggings_count, :with_tag, post: post)
+        create_list(:api_v1_post_tagging, evaluator.post_taggings_count, post: post)
       end
     end
   end

--- a/spec/factories/api/v1/all/posts.rb
+++ b/spec/factories/api/v1/all/posts.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
 
     # https://github.com/thoughtbot/factory_bot/blob/master/GETTING_STARTED.md#associations
     factory :api_v1_post_with_revision_and_post_likings_and_user, class: API::V1::All::Post do
-      association :user, factory: :api_v1_user
+      association :user, factory: [:api_v1_user, :with_profile]
 
       transient do
         revisions_count 5

--- a/spec/factories/api/v1/all/tags.rb
+++ b/spec/factories/api/v1/all/tags.rb
@@ -7,8 +7,8 @@ FactoryBot.define do
         post_taggings_count 5
       end
 
-      after(:create) do |tag, evaluator|
-        create_list(:api_v1_post_tagging, evaluator.post_taggings_count, tag: tag)
+      after(:create) do |_, evaluator|
+        create_list(:api_v1_post_tagging, evaluator.post_taggings_count)
       end
     end
   end

--- a/spec/factories/api/v1/all/users.rb
+++ b/spec/factories/api/v1/all/users.rb
@@ -3,6 +3,10 @@ FactoryBot.define do
     mention_name { Faker::Lorem.characters(5) }
     email        { Faker::Internet.email }
 
+    trait :with_profile do
+      association :profile, factory: :api_v1_profile
+    end
+
     trait :with_profile_and_post_likings do
       association :profile, factory: :api_v1_profile
 

--- a/spec/factories/api/v1/current_user/all/tag_followings.rb
+++ b/spec/factories/api/v1/current_user/all/tag_followings.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :api_v1_current_user_tag_following, class: API::V1::CurrentUser::All::TagFollowing do
+    association :user, factory: :api_v1_current_user_user
+    association :tag,  factory: :api_v1_current_user_tag
+  end
+end

--- a/spec/factories/api/v1/current_user/all/tags.rb
+++ b/spec/factories/api/v1/current_user/all/tags.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :api_v1_current_user_tag, class: API::V1::CurrentUser::All::Tag do
+    name { Faker::Lorem.characters(8) }
+  end
+end

--- a/spec/models/api/v1/all/post_spec.rb
+++ b/spec/models/api/v1/all/post_spec.rb
@@ -6,5 +6,21 @@ RSpec.describe API::V1::All::Post, type: :model do
     it { is_expected.to have_many(:revisions) }
     it { is_expected.to accept_nested_attributes_for(:revisions) }
     it { is_expected.to have_many(:post_likings).dependent(:destroy) }
+    it { is_expected.to have_many(:post_taggings).dependent(:destroy) }
+  end
+
+  describe '.where_filtered_by_tags' do
+    let!(:tag_ids)  { [1, 2] }
+    let!(:post_ids) { [1, 2] }
+    let(:result) { described_class.where(id: post_ids) }
+
+    subject { described_class.where_filtered_by_tags(tag_ids) }
+
+    before do
+      create_list(:api_v1_post_with_revision_and_post_likings_and_user, 2)
+      allow(API::V1::All::PostTagging).to receive(:filtered_post_ids_by).with(tag_ids).and_return(post_ids)
+    end
+
+    it { is_expected.to eq result }
   end
 end

--- a/spec/models/api/v1/all/post_tagging_spec.rb
+++ b/spec/models/api/v1/all/post_tagging_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe API::V1::All::PostTagging, type: :model do
+  describe 'association' do
+    it { is_expected.to belong_to(:tag) }
+    it { is_expected.to belong_to(:post) }
+  end
+
+  describe '.filtered_post_ids_by' do
+    let!(:posts)   { create_list(:api_v1_post, 2) }
+    let!(:tags)    { create_list(:api_v1_tag, 2) }
+    let!(:tag_ids) { tags.pluck(:id) }
+    let(:result)   { posts.pluck(:id) }
+
+    subject { described_class.filtered_post_ids_by(tag_ids) }
+
+    before do
+      create(:api_v1_post_tagging, post: posts[0], tag: tags[0])
+      create(:api_v1_post_tagging, post: posts[1], tag: tags[1])
+    end
+
+    it { is_expected.to eq result }
+  end
+end

--- a/spec/models/api/v1/current_user/all/post_spec.rb
+++ b/spec/models/api/v1/current_user/all/post_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe API::V1::CurrentUser::All::Post, type: :model do
   describe 'association' do
     it { is_expected.to belong_to(:user) }
+    it { is_expected.to have_many(:post_taggings).class_name('API::V1::CurrentUser::All::PostTagging').dependent(:destroy) }
     it { is_expected.to have_many(:revisions) }
     it { is_expected.to accept_nested_attributes_for(:revisions) }
   end

--- a/spec/models/api/v1/current_user/all/tag_following_spec.rb
+++ b/spec/models/api/v1/current_user/all/tag_following_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe API::V1::CurrentUser::All::TagFollowing, type: :model do
+  describe 'association' do
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:tag) }
+  end
+end

--- a/spec/models/api/v1/current_user/all/user_spec.rb
+++ b/spec/models/api/v1/current_user/all/user_spec.rb
@@ -3,6 +3,9 @@ require 'rails_helper'
 RSpec.describe API::V1::CurrentUser::All::User, type: :model do
   describe 'association' do
     it { is_expected.to have_many(:posts).dependent(:destroy) }
+    it { is_expected.to have_many(:post_taggings).class_name('API::V1::CurrentUser::All::PostTagging').through(:posts) }
     it { is_expected.to have_one(:profile).dependent(:destroy) }
+    it { is_expected.to have_many(:post_likings).dependent(:destroy) }
+    it { is_expected.to have_many(:tag_followings).dependent(:destroy) }
   end
 end

--- a/spec/serializers/api/v1/all/current_user_following_tags_post_serializer_spec.rb
+++ b/spec/serializers/api/v1/all/current_user_following_tags_post_serializer_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe API::V1::All::CurrentUserFollowingTagsPostSerializer, type: :serializer do
+  describe 'attirbutes' do
+    it { is_expected.to have_attribute(:user) }
+    it { is_expected.to have_attribute(:profile) }
+    it { is_expected.to have_attribute(:revision) }
+    it { is_expected.to have_attribute(:post_likings_count) }
+    it { is_expected.to have_attribute(:tags) }
+  end
+
+  describe 'association' do
+    # it { is_expected.to have_many(:post_likings) }
+  end
+
+  describe 'instance methods' do
+    let(:post) { create(:api_v1_post_with_revision_and_post_likings_and_user) }
+    let(:serialized_post) { described_class.new(post) }
+
+    describe '#user' do
+      let(:result) { post.user }
+      subject { serialized_post.user }
+
+      it { is_expected.to eq result }
+    end
+
+    describe '#profile' do
+      let(:result) { post.user.profile }
+      subject { serialized_post.profile }
+
+      it { is_expected.to eq result }
+    end
+
+    describe '#revision' do
+      let(:result) { post.revisions.find(post.newest_revision_id) }
+      subject { serialized_post.revision }
+
+      it { is_expected.to eq result }
+    end
+
+    describe '#post_likings_count' do
+      let(:result) { post.post_likings.count }
+      subject { serialized_post.post_likings_count }
+
+      it { is_expected.to eq result }
+    end
+
+    describe '#tags' do
+      let(:result) { API::V1::All::Tag.where(id: post.post_taggings.pluck(:tag_id)) }
+      subject { serialized_post.tags }
+
+      it { is_expected.to eq result }
+    end
+  end
+end

--- a/spec/serializers/api/v1/all/post_liking_serializer_spec.rb
+++ b/spec/serializers/api/v1/all/post_liking_serializer_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe API::V1::All::PostLikingSerializer do
+  describe 'attirbutes' do
+    it { is_expected.to have_attribute(:id) }
+    it { is_expected.to have_attribute(:user_id) }
+    it { is_expected.to have_attribute(:post_id) }
+    it { is_expected.to have_attribute(:from_user_id) }
+    it { is_expected.to have_attribute(:created_at) }
+    it { is_expected.to have_attribute(:updated_at) }
+  end
+end

--- a/spec/serializers/api/v1/all/post_serializer_spec.rb
+++ b/spec/serializers/api/v1/all/post_serializer_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe API::V1::All::PostSerializer, type: :serializer do
+  describe 'attirbutes' do
+    it { is_expected.to have_attribute(:user) }
+    it { is_expected.to have_attribute(:profile) }
+    it { is_expected.to have_attribute(:revision) }
+    it { is_expected.to have_attribute(:post_likings_count) }
+  end
+
+  describe 'association' do
+    # it { is_expected.to have_many(:post_likings) }
+  end
+
+  describe 'instance methods' do
+    let(:post) { create(:api_v1_post_with_revision_and_post_likings_and_user) }
+    let(:serialized_post) { described_class.new(post) }
+
+    describe '#user' do
+      let(:result) { post.user }
+      subject { serialized_post.user }
+
+      it { is_expected.to eq result }
+    end
+
+    describe '#profile' do
+      let(:result) { post.user.profile }
+      subject { serialized_post.profile }
+
+      it { is_expected.to eq result }
+    end
+
+    describe '#revision' do
+      let(:result) { post.revisions.find(post.newest_revision_id) }
+      subject { serialized_post.revision }
+
+      it { is_expected.to eq result }
+    end
+
+    describe '#post_likings_count' do
+      let(:result) { post.post_likings.count }
+      subject { serialized_post.post_likings_count }
+
+      it { is_expected.to eq result }
+    end
+  end
+end


### PR DESCRIPTION
## ストーリー
https://www.pivotaltracker.com/story/show/157175429

## 概要
タグフィード画面でデータ取得をAPI経由で行うようにした。

[バックエンド]
現在のユーザーがフォローしているタグを付けた投稿一覧を返すAPIを実装した。

[フロントエンド]
タグフード画面を実装した。
ページネーションを切り出して共通化した。

## 仕様・注意事項

[フロントエンド]
コンポーネントのテストが相変わらず通らない。(原因不明)

